### PR TITLE
emit next `state` when changing state, not `eventName`

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ Nanostate.prototype.emit = function (eventName) {
   }
 
   this.state = nextState
-  Nanobus.prototype.emit.call(this, eventName)
+  Nanobus.prototype.emit.call(this, nextState)
 }
 
 Nanostate.prototype.event = function (eventName, machine) {

--- a/test/nanostate.js
+++ b/test/nanostate.js
@@ -27,3 +27,16 @@ tape('change state', function (assert) {
   ])
   assert.end()
 })
+
+tape('emit events', function (assert) {
+  var machine = nanostate('idle', {
+    idle: { click: 'loading' }
+  })
+
+  machine.on('loading', function () {
+    assert.pass('an event named after the new state is emitted when state changes')
+    assert.end()
+  })
+
+  machine.emit('click')
+})


### PR DESCRIPTION
- call nanobus.prototype.emit w/ nextState
- add test case

addresses #8 