### PR TITLE
add support for '*' transition entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ Nanostate.prototype.constructor = Nanostate
 
 Nanostate.prototype.emit = function (eventName) {
   var nextState = this._next(eventName)
-
   assert.ok(nextState, 'nanostate.emit: invalid transition' + this.state + '->' + eventName)
 
   if (this._submachine && Object.keys(this.transitions).indexOf(nextState) !== -1) {
@@ -63,8 +62,8 @@ Nanostate.prototype._next = function (eventName) {
     return submachine.state
   }
 
-  if (Object.keys(this.transitions[this.state]).indexOf(eventName) === -1 && Object.keys(this.transitions).indexOf('_any') !== -1) {
-    return this.transitions['_any'][eventName]
+  if (Object.keys(this.transitions[this.state]).indexOf(eventName) === -1 && Object.keys(this.transitions).indexOf('*') !== -1) {
+    return this.transitions['*'][eventName]
   }
 
   return this.transitions[this.state][eventName]

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ Nanostate.prototype.constructor = Nanostate
 
 Nanostate.prototype.emit = function (eventName) {
   var nextState = this._next(eventName)
+
   assert.ok(nextState, 'nanostate.emit: invalid transition' + this.state + '->' + eventName)
 
   if (this._submachine && Object.keys(this.transitions).indexOf(nextState) !== -1) {
@@ -60,6 +61,10 @@ Nanostate.prototype._next = function (eventName) {
   if (submachine) {
     this._submachine = submachine
     return submachine.state
+  }
+
+  if (Object.keys(this.transitions[this.state]).indexOf(eventName) === -1 && Object.keys(this.transitions).indexOf('_any') !== -1) {
+    return this.transitions['_any'][eventName]
   }
 
   return this.transitions[this.state][eventName]

--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ Nanostate.prototype._next = function (eventName) {
     return submachine.state
   }
 
-  if (Object.keys(this.transitions[this.state]).indexOf(eventName) === -1 && Object.keys(this.transitions).indexOf('*') !== -1) {
+  if (!Object.prototype.hasOwnProperty.call(this.transitions[this.state], eventName) &&
+      Object.prototype.hasOwnProperty.call(this.transitions, '*')) {
     return this.transitions['*'][eventName]
   }
 

--- a/test/nanostate.js
+++ b/test/nanostate.js
@@ -40,3 +40,24 @@ tape('emit events', function (assert) {
 
   machine.emit('click')
 })
+
+tape('global transitions', function (assert) {
+  var machine = nanostate('green', {
+    '*': { stop: 'red' },
+    green: { toYellow: 'yellow' },
+    yellow: { toRed: 'red' },
+    red: { toGreen: 'green' }
+  })
+
+  move(assert, machine, [
+    ['toYellow', 'yellow'],
+    ['stop', 'red'],
+    ['toGreen', 'green'],
+    ['stop', 'red'],
+    ['toGreen', 'green'],
+    ['toYellow', 'yellow'],
+    ['toRed', 'red'],
+    ['stop', 'red']
+  ])
+  assert.end()
+})


### PR DESCRIPTION
Inspired  by a state machine in Unity where you can define transitions from 'Any'. This way you can avoid repetition if there is some set of transitions always available no matter in which state we are.

```
const machine = nanostate('idle', {
  '_any': { 
    'reset': 'idle'
  },

  // ...

}
```

Closes https://github.com/choojs/nanostate/issues/14